### PR TITLE
remove bandwidth field

### DIFF
--- a/lib/membrane_opus.ex
+++ b/lib/membrane_opus.ex
@@ -11,14 +11,6 @@ defmodule Membrane.Opus do
   @type channels_t :: 1 | 2
 
   @typedoc """
-  Bitrate used to encode the stream in `bit/s`.
-
-  Opus supports all bitrates from `6 kbit/s` to `510 kbit/s`,
-  so this value has to be in range `6144` to `522240`.
-  """
-  @type bitrate_t :: non_neg_integer
-
-  @typedoc """
   Determines if stream uses self-delimiting framing.
 
   Self-delimiting framing provides information necessary to parse
@@ -27,11 +19,10 @@ defmodule Membrane.Opus do
   @type self_delimiting_t :: boolean
 
   @type t :: %__MODULE__{
-          bitrate: bitrate_t,
           channels: channels_t,
           self_delimiting?: self_delimiting_t
         }
 
-  @enforce_keys [:bitrate, :channels]
+  @enforce_keys [:channels]
   defstruct @enforce_keys ++ [self_delimiting?: false]
 end


### PR DESCRIPTION
Bandwidth can be variable and is never used. We can consider re-adding when needed.