### PR TITLE
Make `:credo` `only: :dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ reason, the package can be installed by adding `membrane_opus_format` to your li
 ```elixir
 def deps do
   [
-    {:membrane_opus_format, "~> 0.3.1"}
+    {:membrane_opus_format, "~> 0.3.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.Opus.Format.Mixfile do
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.3.2"
   @github_url "https://github.com/membraneframework/membrane_opus_format"
 
   def project do
@@ -33,7 +33,7 @@ defmodule Membrane.Opus.Format.Mixfile do
 
   defp deps do
     [
-      {:credo, ">= 0.0.0", runtime: false},
+      {:credo, ">= 0.0.0", only: :dev, runtime: false},
       {:ex_doc, ">= 0.40.0", only: :dev, runtime: false},
       {:dialyxir, ">= 0.0.0", only: :dev, runtime: false}
     ]


### PR DESCRIPTION
`mix deps.get` fails with:

```
Dependencies have diverged:
  * credo (Hex package)
    the :only option for dependency credo

    > In mix.exs:
      {:credo, ">= 0.0.0", [env: :prod, hex: "credo", only: :dev, runtime: false, repo: "hexpm"]}

    does not match the :only option calculated for

    > In deps/membrane_opus_format/mix.exs:
      {:credo, ">= 0.0.0", [env: :prod, hex: "credo", repo: "hexpm", optional: false]}

    Remove the :only restriction from your dep
  ** (Mix) Can't continue due to errors on dependencies
```

for projects that use this package but specify `:credo` as `only: :dev`